### PR TITLE
test(c-api) Enable the memory test example.

### DIFF
--- a/lib/c-api/tests/wasm_c_api/CMakeLists.txt
+++ b/lib/c-api/tests/wasm_c_api/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(wasm-c-api-callback wasm-c-api/example/callback.c)
 add_executable(wasm-c-api-global wasm-c-api/example/global.c)
 add_executable(wasm-c-api-hello wasm-c-api/example/hello.c)
 #add_executable(wasm-c-api-hostref wasm-c-api/example/hostref.c)
-#add_executable(wasm-c-api-memory wasm-c-api/example/memory.c)
+add_executable(wasm-c-api-memory wasm-c-api/example/memory.c)
 #add_executable(wasm-c-api-multi wasm-c-api/example/multi.c)
 add_executable(wasm-c-api-reflect wasm-c-api/example/reflect.c)
 add_executable(wasm-c-api-serialize wasm-c-api/example/serialize.c)
@@ -78,12 +78,12 @@ add_test(NAME wasm-c-api-hello
 #         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/wasm-c-api/example/
 #)
 
-#target_link_libraries(wasm-c-api-memory general ${WASMER_LIB})
-#target_compile_options(wasm-c-api-memory PRIVATE ${COMPILER_OPTIONS})
-#add_test(NAME wasm-c-api-memory
-#         COMMAND wasm-c-api-memory
-#         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/wasm-c-api/example/
-#)
+target_link_libraries(wasm-c-api-memory general ${WASMER_LIB})
+target_compile_options(wasm-c-api-memory PRIVATE ${COMPILER_OPTIONS})
+add_test(NAME wasm-c-api-memory
+         COMMAND wasm-c-api-memory
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/wasm-c-api/example/
+)
 
 #target_link_libraries(wasm-c-api-multi general ${WASMER_LIB})
 #target_compile_options(wasm-c-api-multi PRIVATE ${COMPILER_OPTIONS})


### PR DESCRIPTION
The patch also makes the `memory` test pass!
